### PR TITLE
async stdify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 log = { version = "0.4.8", features = ["std", "kv_unstable"] }
 backtrace = "0.3.34"
 async-log-attributes = { path = "async-log-attributes", version = "1.0.1" }
+async-std = "0.99.9"
 
 [dev-dependencies]
 femme = "1.2.0"

--- a/examples/trace.rs
+++ b/examples/trace.rs
@@ -1,22 +1,25 @@
 use async_log::{instrument, span};
+use async_std::task;
 use log::info;
 
 fn setup_logger() {
     let logger = femme::pretty::Logger::new();
-    async_log::Logger::wrap(logger, || /* get the task id here */ 0)
+    async_log::Logger::wrap(logger)
         .start(log::LevelFilter::Trace)
         .unwrap();
 }
 
 fn main() {
-    setup_logger();
+    task::block_on(async {
+        setup_logger();
 
-    span!("level {}", 1, {
-        let x = "beep";
-        info!("look at this value: {}", x);
+        span!("level {}", 1, {
+            let x = "beep";
+            info!("look at this value: {}", x);
 
-        span!("level {}", 2, {
-            inner("boop");
+            span!("level {}", 2, {
+                inner("boop");
+            })
         })
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,26 +78,27 @@
 //! ## Example
 //!
 //! ```rust
-//! use async_log::span;
-//! use log::info;
+//! use async_std::task;
 //!
 //! fn setup_logger() {
 //!     let logger = femme::pretty::Logger::new();
-//!     async_log::Logger::wrap(logger, || 12)
+//!     async_log::Logger::wrap(logger)
 //!         .start(log::LevelFilter::Trace)
 //!         .unwrap();
 //! }
 //!
 //! fn main() {
-//!     setup_logger();
+//!     task::block_on(async {
+//!         setup_logger();
 //!
-//!     span!("new level, depth={}", 1, {
-//!         let x = "beep";
-//!         info!("look at this value, x={}", x);
+//!         async_log::span!("new level, depth={}", 1, {
+//!             let x = "beep";
+//!             log::info!("look at this value, x={}", x);
 //!
-//!         span!("new level, depth={}", 2, {
-//!             let y = "boop";
-//!             info!("another nice value, y={}", y);
+//!             async_log::span!("new level, depth={}", 2, {
+//!                 let y = "boop";
+//!                 log::info!("another nice value, y={}", y);
+//!             })
 //!         })
 //!     })
 //! }


### PR DESCRIPTION
This removes the `with` clause, making the crate work with `async-std` out of the box. This should make it substantially easier to setup, and with https://github.com/yoshuawuyts/kv-log-macro it can be used to easily capture rich logs in async environments.

Thanks heaps!