### PR TITLE
Update dependencies of async-log-attributes and make it to be optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ before_script: |
   rustup component add clippy-preview
 script: |
   cargo fmt -- --check &&
-  cargo clippy -- -D clippy &&
+  cargo clippy -- -D all &&
   cargo build --verbose &&
-  cargo test  --verbose
+  cargo build --no-default-features --verbose &&
+  cargo test  --verbose &&
+  cargo test --no-default-features --verbose
 cache: cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,22 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 edition = "2018"
 
+[features]
+default = ["attributes"]
+attributes = ["async-log-attributes"]
+
 [dependencies]
 log = { version = "0.4.8", features = ["std", "kv_unstable"] }
 backtrace = "0.3.34"
-async-log-attributes = { path = "async-log-attributes", version = "1.0.1" }
+async-log-attributes = { path = "async-log-attributes", version = "1.0.1", optional = true }
 
 [dev-dependencies]
 femme = "1.2.0"
+
+[[example]]
+name = "trace"
+path = "examples/trace.rs"
+required-features = ["attributes"]
 
 [workspace]
 members = [

--- a/async-log-attributes/Cargo.toml
+++ b/async-log-attributes/Cargo.toml
@@ -16,6 +16,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15.33", features = ["full"] }
-proc-macro2 = { version = "0.4.29", features = ["nightly"] }
-quote = "0.6.12"
+syn = { version = "1.0", features = ["full"] }
+proc-macro2 = "1.0"
+quote = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,19 +88,19 @@
 //!         .unwrap();
 //! }
 //!
-//! fn main() {
-//!     setup_logger();
 //!
-//!     span!("new level, depth={}", 1, {
-//!         let x = "beep";
-//!         info!("look at this value, x={}", x);
+//! setup_logger();
 //!
-//!         span!("new level, depth={}", 2, {
-//!             let y = "boop";
-//!             info!("another nice value, y={}", y);
-//!         })
+//! span!("new level, depth={}", 1, {
+//!     let x = "beep";
+//!     info!("look at this value, x={}", x);
+//!
+//!     span!("new level, depth={}", 2, {
+//!         let y = "boop";
+//!         info!("another nice value, y={}", y);
 //!     })
-//! }
+//! })
+//!
 //! ```
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
@@ -108,6 +108,7 @@
 #![warn(missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 
+#[cfg(feature = "attributes")]
 pub use async_log_attributes::instrument;
 
 use std::fmt::Arguments;


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* Update `proc-maroc2`, `syn` and `quote` to v1.0
* Make `async-log-attributes` to be optional (close #6)